### PR TITLE
Added missing :created_at_int on AccountOperation

### DIFF
--- a/lib/paytunia/models/account_operation.rb
+++ b/lib/paytunia/models/account_operation.rb
@@ -1,7 +1,7 @@
 module Paytunia
   module Api
     class AccountOperation < Base
-      attrs :uuid, :amount, :currency, :created_at, :state, :type, :balance
+      attrs :uuid, :amount, :currency, :created_at, :state, :type, :balance, :created_at_int
     end
   end
 end

--- a/paytunia.gemspec
+++ b/paytunia.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'rake'
 
-  s.files        = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md)
+  s.files        = Dir.glob('{bin,lib,certs}/**/*') + %w(LICENSE README.md)
   s.executables  = ['paytunia']
   s.require_path = 'lib'
 end


### PR DESCRIPTION
When calling /account_operations, the server returns a created_at_int in addition to created_at causing AccountOperation instanciation to fail.

This juste adds the missing field in AccountOperation model.
